### PR TITLE
fixing bad pdf path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dmypy.json
 # passwords
 vm/vm_passwords.yml
 
+pdf
+used_journals_only_file.tsv

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Currently only tested on mac. create a virtual environment using the requirement
 
 * Generalize to work on windows - use os.path.join instead of slashes using (os.path.sep) and os.path.join.
 
+* Change __full_path__ field name in doi database table to __relative_path__ and propagate change across package
+
 Can't download these; it should work! 10.3390/plants11071002 10.3390/plants11081024 10.3390/plants11081012 are
 similar.
 

--- a/scan.py
+++ b/scan.py
@@ -186,7 +186,7 @@ class Scan:
             os.makedirs(directory)
 
         try:
-            pdf_path = f"{os.getcwd()}/{self.doi_object.full_path}"
+            pdf_path = self.doi_object.full_path
             text = self.extract_text_from_pdf(pdf_path)
             tables = self.extract_tables_from_pdf(pdf_path)
 


### PR DESCRIPTION
Fixing bad pdf_path in scan.py. 

Line 189: pdf_path = f"{os.getcwd()}/{self.doi_object.full_path}"

This was a duplicative path, as the _self.doi_object.full_path_ already included the current working directory, so the pdf_path looked like _/User/dangause/citations_finder/User/dangause/citation_finder/pdf/pdf/..._
This in turn lead to a file not found error.

The bfix simply set pdf_path to _pdf_path = self.doi_object.full_path_ which runs correctly.